### PR TITLE
Changed NuGetDir for Xamarin.iOS to support Xamarin.Mac

### DIFF
--- a/grunt/Gruntfile.js
+++ b/grunt/Gruntfile.js
@@ -13,7 +13,7 @@ module.exports = function (grunt) {
       { "Name": "EngineIoClientDotNet.net45", "NuGetDir": "net45", "SourceDir": "" },
       { "Name": "EngineIoClientDotNet.windowsphone8", "NuGetDir": "windowsphone8", "SourceDir": "windowsphone8" },
       { "Name": "EngineIoClientDotNet.netcore45", "NuGetDir": "netcore45", "SourceDir": "", copyOnly: true },
-      { "Name": "EngineIoClientDotNet.Xamarin-iOS", "NuGetDir": "xamarinios10", "SourceDir": "" },
+      { "Name": "EngineIoClientDotNet.Xamarin-iOS", "NuGetDir": "portable-Xamarin.iOS10+Xamarin.Mac20", "SourceDir": "" },
       { "Name": "EngineIoClientDotNet.Xamarin-MonoTouch", "NuGetDir": "monotouch10", "SourceDir": "monotouch10" },
       { "Name": "EngineIoClientDotNet.Xamarin-Android", "NuGetDir": "monoandroid10", "SourceDir": "", copyOnly: true },
       { "Name": "EngineIoClientDotNet.portable-wpa81+wp81", "NuGetDir": "portable-wpa81+wp81", "SourceDir": "" },

--- a/grunt/templates/EngineIoClientDotNet.nuspec
+++ b/grunt/templates/EngineIoClientDotNet.nuspec
@@ -39,6 +39,10 @@
         <dependency id="WebSocket4Net" version="0.14.1" />
         <dependency id="Newtonsoft.Json" version="8.0.1" />
       </group>
+      <group targetFramework="Xamarin.Mac20">
+        <dependency id="WebSocket4Net" version="0.14.1" />
+        <dependency id="Newtonsoft.Json" version="8.0.1" />
+      </group>
       <group targetFramework="monotouch10">
         <dependency id="WebSocket4Net" version="0.14.1" />
         <dependency id="Newtonsoft.Json" version="8.0.1" />


### PR DESCRIPTION
From what I can tell (and what I tested), the Xamarin.iOS version does not use any iOS specific features.  Given that and since Xamarin.Mac is IL compatible with Xamarin.iOS, the current Xamarin.iOS dll can be put into a special NuGetDir that will open support for Xamarin.Mac as well as continue to support Xamarin.iOS.