### PR TITLE
Fix async operation issue when used in ASP.NET

### DIFF
--- a/Src/EngineIoClientDotNet.mono/Client/Socket.cs
+++ b/Src/EngineIoClientDotNet.mono/Client/Socket.cs
@@ -621,14 +621,17 @@ namespace Quobject.EngineIoClientDotNet.Client
             SendPacket(new Packet(type, data), fn);
         }
 
-        private async void SendPacket(Packet packet, Action fn)
+        private void SendPacket(Packet packet, Action fn)
         {
             if (fn == null)
             {
                 fn = () => { };
             }
 
-            await WaitForUpgrade();
+            if (Upgrading)
+            {
+                WaitForUpgrade().Wait();
+            }
 
             Emit(EVENT_PACKET_CREATE, packet);
             //var log = LogManager.GetLogger(Global.CallerName());


### PR DESCRIPTION
Issue: 
Changing SendPacket to an async void method caused the following when used in an ASP.NET MVC application

> System.InvalidOperationException: An asynchronous operation cannot be started at this time. Asynchronous operations may only be started within an asynchronous handler or module or during certain events in the Page lifecycle. If this exception occurred while executing a Page, ensure that the Page is marked <%@ Page Async="true" %>. This exception may also indicate an attempt to call an "async void" method, which is generally unsupported within ASP.NET request processing. Instead, the asynchronous method should return a Task, and the caller should await it.

Resolution:
Wait for the WaitForUpgrade task to complete synchronously and remove the async modifier from SendPacket.

Note:
The alternative to synchronously waiting is to propagate the async/await pattern up through all methods that call SendPacket, this is a much larger change than I am comfortable making at this point in time. 