### PR TITLE
Fix flush failed when upgrading

### DIFF
--- a/Src/EngineIoClientDotNet.mono/Client/Socket.cs
+++ b/Src/EngineIoClientDotNet.mono/Client/Socket.cs
@@ -838,8 +838,8 @@ namespace Quobject.EngineIoClientDotNet.Client
                                 {
                                     _onTransportOpenListener.Parameters.Transport[0].Send(packetList);
 
-                                    _onTransportOpenListener.Parameters.Socket.Flush();
                                     _onTransportOpenListener.Parameters.Socket.Upgrading = false;
+                                    _onTransportOpenListener.Parameters.Socket.Flush();
 
                                     _onTransportOpenListener.Parameters.Socket.Emit(EVENT_UPGRADE,
                                         _onTransportOpenListener.Parameters.Transport[0]);


### PR DESCRIPTION
`Upgrading` needs to be set before the `Flush` is called. Otherwise the `Flush` will always fail.

From a user's view, an `Emit` will not be sent to the server immediately after the upgrading. This will cause a delay of about several seconds.