### PR TITLE
Don't UTF8 decode an already decoded string

### DIFF
--- a/Src/EngineIoClientDotNet.mono/Parser/Packet.cs
+++ b/Src/EngineIoClientDotNet.mono/Parser/Packet.cs
@@ -247,7 +247,7 @@ namespace Quobject.EngineIoClientDotNet.Parser
 
                     if (msg.Length != 0)
                     {
-                        Packet packet = DecodePacket(msg, true);
+                        Packet packet = DecodePacket(msg, false);
                         if (_err.Type == packet.Type && _err.Data == packet.Data)
                         {
                             callback.Call(_err, 0, 1);


### PR DESCRIPTION
When polling the string returned by StreamReader.ReadToEnd is already UTF8 decoded.  Trying to decode it 2nd time fails and as a result polling is broken for international strings.  This fixes that issue.