### PR TITLE
Fixed ping and heartbeat issue when receiving lots of messages [.NET 3.5]

### DIFF
--- a/Src/EngineIoClientDotNet.mono/Thread/Heartbeat_net35.cs
+++ b/Src/EngineIoClientDotNet.mono/Thread/Heartbeat_net35.cs
@@ -1,0 +1,55 @@
+using System;
+using System.ComponentModel;
+using System.Threading;
+
+namespace Quobject.EngineIoClientDotNet.Thread
+{
+    public class Heartbeat
+    {
+        private volatile bool gotHeartbeat = false;
+        private BackgroundWorker heartBeatTimer;
+        private CancellationTokenSource ts;
+
+        private Heartbeat()
+        {
+            ts = new CancellationTokenSource();
+        }
+
+        public static Heartbeat Start(Action onTimeout, int timeout)
+        {
+            Heartbeat heartbeat = new Heartbeat();
+            heartbeat.Run(onTimeout, timeout);
+            return heartbeat;            
+        }
+
+        public void OnHeartbeat()
+        {
+            gotHeartbeat = true;
+        }
+
+        private void Run(Action onTimeout, int timeout)
+        {
+            heartBeatTimer = new BackgroundWorker();
+
+            heartBeatTimer.DoWork += (s, e) =>
+            {
+                while (!ts.IsCancellationRequested)
+                {
+                    System.Threading.Thread.Sleep(timeout);
+                    if (!gotHeartbeat && !ts.IsCancellationRequested)
+                    {
+                        onTimeout();
+                        break;
+                    }
+                }
+            };
+
+            heartBeatTimer.RunWorkerAsync();
+        }
+
+        public void Stop()
+        {
+            ts.Cancel();
+        }
+    }
+}

--- a/Src/EngineIoClientDotNet.mono/Thread/TriggeredLoopTimer_net35.cs
+++ b/Src/EngineIoClientDotNet.mono/Thread/TriggeredLoopTimer_net35.cs
@@ -1,0 +1,61 @@
+using System;
+using System.ComponentModel;
+using System.Threading;
+
+namespace Quobject.EngineIoClientDotNet.Thread
+{
+    public class TriggeredLoopTimer
+    {
+        private ManualResetEvent trigger;
+        private CancellationTokenSource ts;
+
+        private TriggeredLoopTimer()
+        {
+            trigger = new ManualResetEvent(false);
+            ts = new CancellationTokenSource();
+        }
+
+        public static TriggeredLoopTimer Start (Action method, int delayInMilliseconds)
+        {
+            TriggeredLoopTimer ping = new TriggeredLoopTimer();
+            ping.Run (method, delayInMilliseconds);
+            return ping;
+        }
+
+
+        public void Trigger()
+        {
+            trigger.Set();
+        }
+
+        private void Run (Action method, int delayInMilliseconds)
+        {
+            var worker = new BackgroundWorker();
+
+            worker.DoWork += (s, e) =>
+            {
+                while (!ts.IsCancellationRequested)
+                {
+                    System.Threading.Thread.Sleep (delayInMilliseconds);
+                    if (!ts.IsCancellationRequested)
+                    {
+                        method();
+                        trigger.WaitOne();
+                        trigger.Reset();
+                    }
+                }
+            };
+
+            worker.RunWorkerAsync();
+        }
+
+        public void Stop()
+        {
+            if (ts != null)
+            {
+                ts.Cancel();
+                trigger.Set();
+            }
+        }
+    }
+}

--- a/Src/EngineIoClientDotNet.net35/EngineIoClientDotNet.net35.csproj
+++ b/Src/EngineIoClientDotNet.net35/EngineIoClientDotNet.net35.csproj
@@ -115,6 +115,12 @@
     <Compile Include="..\EngineIoClientDotNet.mono\Thread\EasyTimer_net35.cs">
       <Link>Thread\EasyTimer_net35.cs</Link>
     </Compile>
+    <Compile Include="..\EngineIoClientDotNet.mono\Thread\Heartbeat_net35.cs">
+      <Link>Thread\Heartbeat_net35.cs</Link>
+    </Compile>
+    <Compile Include="..\EngineIoClientDotNet.mono\Thread\TriggeredLoopTimer_net35.cs">
+      <Link>Thread\TriggeredLoopTimer_net35.cs</Link>
+    </Compile>
     <Compile Include="Parser\Packet_net35.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
Ping and heartbeat stopped working when lots of messages were received continously due to their threads not starting.
Once a Thread runs, it behaves as expected, even under heavy load.
Switched to triggered thread implementations which run loops to avoid having to start a new thread every time a ping or heartbeat event occours.

This fixed #36 for me.
Still didn't test for other than .NET 3.5