### PR TITLE
fix pinging during upgrades

### DIFF
--- a/Src/EngineIoClientDotNet.mono/Client/Socket.cs
+++ b/Src/EngineIoClientDotNet.mono/Client/Socket.cs
@@ -567,9 +567,18 @@ namespace Quobject.EngineIoClientDotNet.Client
                 var log2 = LogManager.GetLogger(Global.CallerName());
                 log2.Info("EasyTimer SetPing start");
 
-                Ping();
-                OnHeartbeat(PingTimeout);
-                log2.Info("EasyTimer SetPing finish");
+                if (Upgrading)
+                {
+                    // skip this ping during upgrade
+                    SetPing();
+                    log2.Info("skipping Ping during upgrade");
+                }
+                else
+                {
+                    Ping();
+                    OnHeartbeat(PingTimeout);
+                    log2.Info("EasyTimer SetPing finish");
+                }
             }, (int)PingInterval);
         }
 
@@ -662,6 +671,11 @@ namespace Quobject.EngineIoClientDotNet.Client
                     {
                         log.Info("Wait for upgrade timeout");
                         break;
+                    }
+                    else
+                    {
+                        // yield to another thread
+                        System.Threading.Thread.Yield();
                     }
                 }
                 tcs.SetResult(null);


### PR DESCRIPTION
Right now in some situations pinging will always fall during transport upgrades creating an infinite loop:
ping during upgrade is dropped -> connection fails due to ping timeout -> connection re-established -> connection starts upgrading -> ping during upgrade is dropped ....
This is aggravated by the fact that upgrading can happen on the same thread that busy loops while waiting for the upgrade to complete.  So two fixes with this pull request:
1) skip a ping during upgrade
2) yield to another thread for a  "thread time slice interval" (which is a few milliseconds) while waiting for the upgrade
