### PR TITLE
resume polling on transport upgrade failure

### DIFF
--- a/Src/EngineIoClientDotNet.mono/Client/Socket.cs
+++ b/Src/EngineIoClientDotNet.mono/Client/Socket.cs
@@ -836,6 +836,10 @@ namespace Quobject.EngineIoClientDotNet.Client
                             {
                                 if (_onTransportOpenListener.Parameters.Failed[0])
                                 {
+                                    // reset upgrading flag and resume polling
+                                    ((Polling)_onTransportOpenListener.Parameters.Socket.Transport).Resume();
+                                    _onTransportOpenListener.Parameters.Socket.Upgrading = false;
+                                    _onTransportOpenListener.Parameters.Socket.Flush();
                                     return;
                                 }
                                 if (ReadyStateEnum.CLOSED == _onTransportOpenListener.Parameters.Socket.ReadyState ||

--- a/Src/EngineIoClientDotNet.mono/Client/Transports/Polling.cs
+++ b/Src/EngineIoClientDotNet.mono/Client/Transports/Polling.cs
@@ -67,6 +67,12 @@ namespace Quobject.EngineIoClientDotNet.Client.Transports
             }
         }
 
+        public void Resume()
+        {
+            if (ReadyState == ReadyStateEnum.PAUSED)
+                ReadyState = ReadyStateEnum.OPEN;
+        }
+
         private class PauseEventDrainListener : IListener
         {
             private int[] total;


### PR DESCRIPTION
If a transport upgrade fails in the middle of negotiation resume paused polling transport.  Otherwise we're left in a bad state where the new transport failed and the old transport is paused indefinitely in an "upgrading" state.