### PR TITLE
Allow for TLS (HTTPS) through a web proxy when using web sockets

### DIFF
--- a/Src/EngineIoClientDotNet.mono/Client/Socket.cs
+++ b/Src/EngineIoClientDotNet.mono/Client/Socket.cs
@@ -672,6 +672,11 @@ namespace Quobject.EngineIoClientDotNet.Client
                         log.Info("Wait for upgrade timeout");
                         break;
                     }
+                    else
+                    {
+                        // yield to another thread 
+                        System.Threading.Thread.Yield();
+                    }
                 }
                 tcs.SetResult(null);
             }

--- a/Src/EngineIoClientDotNet.mono/Client/Transports/WebSocket.cs
+++ b/Src/EngineIoClientDotNet.mono/Client/Transports/WebSocket.cs
@@ -37,7 +37,7 @@ namespace Quobject.EngineIoClientDotNet.Client.Transports
             var log = LogManager.GetLogger(Global.CallerName());
             log.Info("DoOpen uri =" + this.Uri());
 
-            ws = new WebSocket4Net.WebSocket(this.Uri(), "", Cookies, MyExtraHeaders)
+            ws = new WebSocket4Net.WebSocket(this.Uri(), String.Empty, Cookies, MyExtraHeaders)
             {
                 EnableAutoSendPing = false
             };
@@ -66,14 +66,8 @@ namespace Quobject.EngineIoClientDotNet.Client.Transports
             if (useProxy)
             {
                 var proxyUrl = WebRequest.DefaultWebProxy.GetProxy(destUrl.Uri);
-                var proxy = new HttpConnectProxy(new DnsEndPoint(proxyUrl.Host, proxyUrl.Port));
+                var proxy = new HttpConnectProxy(new DnsEndPoint(proxyUrl.Host, proxyUrl.Port), destUrl.Host);
                 ws.Proxy = proxy;
-                // for not websocket has a bug where the cert is checked against
-                // the proxy name instead of the host name.  disable name check
-                ws.Security.AllowNameMismatchCertificate = true;
-                // ensure we only trusts certificates from trusted issuers
-                // to minimize security hole created by lack of name check
-                ws.Security.AllowUnstrustedCertificate = false;
             }
             ws.Open();
         }

--- a/Src/EngineIoClientDotNet.mono/Parser/Packet.cs
+++ b/Src/EngineIoClientDotNet.mono/Parser/Packet.cs
@@ -247,7 +247,7 @@ namespace Quobject.EngineIoClientDotNet.Parser
 
                     if (msg.Length != 0)
                     {
-                        Packet packet = DecodePacket(msg, true);
+                        Packet packet = DecodePacket(msg, false);
                         if (_err.Type == packet.Type && _err.Data == packet.Data)
                         {
                             callback.Call(_err, 0, 1);

--- a/Src/EngineIoClientDotNet.net45/.vs/config/applicationhost.config
+++ b/Src/EngineIoClientDotNet.net45/.vs/config/applicationhost.config
@@ -163,7 +163,7 @@
             </site>
             <site name="grunt" id="2">
                 <application path="/" applicationPool="Clr4IntegratedAppPool">
-                    <virtualDirectory path="/" physicalPath="C:\Users\leszek\Source\Repos\EngineIoClientDotNet\grunt" />
+                    <virtualDirectory path="/" physicalPath="C:\EngineIoClientDotNet\grunt" />
                 </application>
                 <bindings>
                     <binding protocol="http" bindingInformation="*:8678:localhost" />
@@ -171,7 +171,7 @@
             </site>
             <site name="TestServer" id="3">
                 <application path="/" applicationPool="Clr4IntegratedAppPool">
-                    <virtualDirectory path="/" physicalPath="C:\Users\leszek\Source\Repos\EngineIoClientDotNet\TestServer" />
+                    <virtualDirectory path="/" physicalPath="C:\EngineIoClientDotNet\TestServer" />
                 </application>
                 <bindings>
                     <binding protocol="http" bindingInformation="*:8671:localhost" />

--- a/Src/EngineIoClientDotNet.net45/.vs/config/applicationhost.config
+++ b/Src/EngineIoClientDotNet.net45/.vs/config/applicationhost.config
@@ -163,7 +163,7 @@
             </site>
             <site name="grunt" id="2">
                 <application path="/" applicationPool="Clr4IntegratedAppPool">
-                    <virtualDirectory path="/" physicalPath="C:\EngineIoClientDotNet\grunt" />
+                    <virtualDirectory path="/" physicalPath="C:\Users\leszek\Source\Repos\EngineIoClientDotNet\grunt" />
                 </application>
                 <bindings>
                     <binding protocol="http" bindingInformation="*:8678:localhost" />
@@ -171,7 +171,7 @@
             </site>
             <site name="TestServer" id="3">
                 <application path="/" applicationPool="Clr4IntegratedAppPool">
-                    <virtualDirectory path="/" physicalPath="C:\EngineIoClientDotNet\TestServer" />
+                    <virtualDirectory path="/" physicalPath="C:\Users\leszek\Source\Repos\EngineIoClientDotNet\TestServer" />
                 </application>
                 <bindings>
                     <binding protocol="http" bindingInformation="*:8671:localhost" />

--- a/Src/EngineIoClientDotNet.net45/EngineIoClientDotNet.net45.csproj
+++ b/Src/EngineIoClientDotNet.net45/EngineIoClientDotNet.net45.csproj
@@ -35,9 +35,8 @@
       <HintPath>packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="SuperSocket.ClientEngine, Version=0.8.0.12, Culture=neutral, PublicKeyToken=ee9af13f57f00acc, processorArchitecture=MSIL">
-      <HintPath>packages\SuperSocket.ClientEngine.Core.0.8.0.12\lib\net45\SuperSocket.ClientEngine.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="SuperSocket.ClientEngine, Version=0.8.0.13, Culture=neutral, PublicKeyToken=ee9af13f57f00acc, processorArchitecture=MSIL">
+      <HintPath>packages\SuperSocket.ClientEngine.Core.0.8.0.13\lib\net45\SuperSocket.ClientEngine.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -45,8 +44,7 @@
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="WebSocket4Net, Version=0.15.0.9, Culture=neutral, PublicKeyToken=eb4e154b696bf72a, processorArchitecture=MSIL">
-      <HintPath>packages\WebSocket4Net.0.15.0-beta9\lib\net45\WebSocket4Net.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>packages\WebSocket4Net.0.15.0\lib\net45\WebSocket4Net.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Src/EngineIoClientDotNet.net45/packages.config
+++ b/Src/EngineIoClientDotNet.net45/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="SuperSocket.ClientEngine.Core" version="0.8.0.12" targetFramework="net45" />
+  <package id="SuperSocket.ClientEngine.Core" version="0.8.0.13" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net45" />
-  <package id="WebSocket4Net" version="0.15.0-beta9" targetFramework="net45" />
+  <package id="WebSocket4Net" version="0.15.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Today using web sockets transport through a web proxy is broken since the certificate check is done against the proxy name instead of the target host hame. There are two parts to this fix:
part 1: (pre-requites for changes in EngineIoClientDotNet)
Add support for specifying the target host hame when creating and using the http proxy in the super socket client.  This pull request (https://github.com/kerryjiang/SuperSocket.ClientEngine/pull/70) was created for that purpose.  The PR was merged and a new release of SuperSocket and WebSocket4Net were created.
part 2: (changes in EngineIoClientDotNet - this PR)
- Pickup the new NuGet packages for SuuperSocket that contain my PR for proxy support
- In the web socket transport check if we have a system proxy set.  If yes, then create it and use it to create a web socket through the proxy
- re-add the fix for UTF-8 in polling.