### PR TITLE
Exposed SslProtocols option

### DIFF
--- a/Src/EngineIoClientDotNet.mono/Client/Socket.cs
+++ b/Src/EngineIoClientDotNet.mono/Client/Socket.cs
@@ -7,6 +7,7 @@ using Quobject.EngineIoClientDotNet.Parser;
 using Quobject.EngineIoClientDotNet.Thread;
 using System;
 using System.Collections.Generic;
+using System.Security.Authentication;
 using System.Threading.Tasks;
 
 
@@ -44,6 +45,7 @@ namespace Quobject.EngineIoClientDotNet.Client
 
 
         private bool Secure;
+        private SslProtocols SslProtocols;
         private bool Upgrade;
         private bool TimestampRequests = true;
         private bool Upgrading;
@@ -140,6 +142,7 @@ namespace Quobject.EngineIoClientDotNet.Client
             }
 
             Secure = options.Secure;
+            SslProtocols = options.SslProtocols;
             Hostname = options.Hostname;
             Port = options.Port;
             Query = options.QueryString != null ? ParseQS.Decode(options.QueryString) : new Dictionary<string, string>();
@@ -208,6 +211,7 @@ namespace Quobject.EngineIoClientDotNet.Client
                 Hostname = Hostname,
                 Port = Port,
                 Secure = Secure,
+                SslProtocols = SslProtocols,
                 Path = Path,
                 Query = query,
                 TimestampRequests = TimestampRequests,

--- a/Src/EngineIoClientDotNet.mono/Client/Transport.cs
+++ b/Src/EngineIoClientDotNet.mono/Client/Transport.cs
@@ -6,6 +6,7 @@ using Quobject.EngineIoClientDotNet.Modules;
 using Quobject.EngineIoClientDotNet.Parser;
 using System;
 using System.Collections.Generic;
+using System.Security.Authentication;
 
 
 namespace Quobject.EngineIoClientDotNet.Client
@@ -55,6 +56,7 @@ namespace Quobject.EngineIoClientDotNet.Client
         public Dictionary<string, string> Query;
 
         protected bool Secure;
+        protected SslProtocols SslProtocols;
         protected bool TimestampRequests;
         protected int Port;
         protected string Path;
@@ -77,6 +79,7 @@ namespace Quobject.EngineIoClientDotNet.Client
             this.Hostname = options.Hostname;
             this.Port = options.Port;
             this.Secure = options.Secure;
+            this.SslProtocols = options.SslProtocols;
             this.Query = options.Query;
             this.TimestampParam = options.TimestampParam;
             this.TimestampRequests = options.TimestampRequests;
@@ -183,6 +186,7 @@ namespace Quobject.EngineIoClientDotNet.Client
             public string Path;
             public string TimestampParam;
             public bool Secure = false;
+            public SslProtocols SslProtocols;
             public bool TimestampRequests = true;
             public int Port;
             public int PolicyPort;

--- a/Src/EngineIoClientDotNet.mono/Client/Transports/WebSocket.cs
+++ b/Src/EngineIoClientDotNet.mono/Client/Transports/WebSocket.cs
@@ -3,6 +3,7 @@ using Quobject.EngineIoClientDotNet.Parser;
 using System;
 using System.Net;
 using System.Collections.Generic;
+using System.Security.Authentication;
 using WebSocket4Net;
 using SuperSocket.ClientEngine.Proxy;
 
@@ -37,7 +38,7 @@ namespace Quobject.EngineIoClientDotNet.Client.Transports
             var log = LogManager.GetLogger(Global.CallerName());
             log.Info("DoOpen uri =" + this.Uri());
 
-            ws = new WebSocket4Net.WebSocket(this.Uri(), String.Empty, Cookies, MyExtraHeaders)
+            ws = new WebSocket4Net.WebSocket(this.Uri(), String.Empty, Cookies, MyExtraHeaders, sslProtocols: SslProtocols)
             {
                 EnableAutoSendPing = false
             };


### PR DESCRIPTION
Exposed the SslProtocols option and pass them all the way to the `WebSocket4Net.WebSocket` instance.

Simply use the `System.Security.Authentication.SslProtocols` enumeration to pass the proper value to the options like this:

![image](https://user-images.githubusercontent.com/16145977/42383215-9ff422e8-8104-11e8-8d19-c67395c3fab0.png)

Fix for:
https://github.com/Quobject/SocketIoClientDotNet/issues/142
