### PR TITLE
Add the SslProtocols option to .NET 3.5 and 4.0

### DIFF
--- a/Src/EngineIoClientDotNet.mono/Client/Socket_net35.cs
+++ b/Src/EngineIoClientDotNet.mono/Client/Socket_net35.cs
@@ -5,6 +5,8 @@ using Quobject.EngineIoClientDotNet.Parser;
 using Quobject.EngineIoClientDotNet.Thread;
 using System;
 using System.Collections.Generic;
+using System.Security.Authentication;
+
 //using System.Threading.Tasks;
 
 
@@ -42,6 +44,7 @@ namespace Quobject.EngineIoClientDotNet.Client
 
 
         private bool Secure;
+        private SslProtocols SslProtocols;
         private bool Upgrade;
         private bool TimestampRequests = true;
         private bool Upgrading;
@@ -136,6 +139,7 @@ namespace Quobject.EngineIoClientDotNet.Client
             }
 
             Secure = options.Secure;
+            SslProtocols = options.SslProtocols;
             Hostname = options.Hostname;
             Port = options.Port;
             Query = options.QueryString != null ? ParseQS.Decode(options.QueryString) : new Dictionary<string, string>();
@@ -196,6 +200,7 @@ namespace Quobject.EngineIoClientDotNet.Client
             options.Hostname = Hostname;
             options.Port = Port;
             options.Secure = Secure;
+            options.SslProtocols = SslProtocols;
             options.Path = Path;
             options.Query = query;
             options.TimestampRequests = TimestampRequests;

--- a/Src/EngineIoClientDotNet.mono/Client/Transport_net35.cs
+++ b/Src/EngineIoClientDotNet.mono/Client/Transport_net35.cs
@@ -7,6 +7,7 @@ using Quobject.EngineIoClientDotNet.Modules;
 using Quobject.EngineIoClientDotNet.Parser;
 using System;
 using System.Collections.Generic;
+using System.Security.Authentication;
 
 
 namespace Quobject.EngineIoClientDotNet.Client
@@ -56,6 +57,7 @@ namespace Quobject.EngineIoClientDotNet.Client
         public Dictionary<string, string> Query;
 
         protected bool Secure;
+        protected SslProtocols SslProtocols;
         protected bool TimestampRequests;
         protected int Port;
         protected string Path;
@@ -76,6 +78,7 @@ namespace Quobject.EngineIoClientDotNet.Client
             this.Hostname = options.Hostname;
             this.Port = options.Port;
             this.Secure = options.Secure;
+            this.SslProtocols = options.SslProtocols;
             this.Query = options.Query;
             this.TimestampParam = options.TimestampParam;
             this.TimestampRequests = options.TimestampRequests;
@@ -181,6 +184,7 @@ namespace Quobject.EngineIoClientDotNet.Client
             public string Path;
             public string TimestampParam;
             public bool Secure = false;
+            public SslProtocols SslProtocols;
             public bool TimestampRequests = true;
             public int Port;
             public int PolicyPort;

--- a/Src/EngineIoClientDotNet.mono/Client/Transports/WebSocket_net35.cs
+++ b/Src/EngineIoClientDotNet.mono/Client/Transports/WebSocket_net35.cs
@@ -31,7 +31,7 @@ namespace Quobject.EngineIoClientDotNet.Client.Transports
             var log = LogManager.GetLogger(Global.CallerName());
             log.Info("DoOpen uri =" + this.Uri());
 
-            ws = new WebSocket4Net.WebSocket(this.Uri(),"",Cookies);
+            ws = new WebSocket4Net.WebSocket(this.Uri(),"",Cookies, sslProtocols: SslProtocols);
             ws.EnableAutoSendPing = false;
             if (ServerCertificate.Ignore)
             {


### PR DESCRIPTION
The library for .NET 3.5 and 4.0 is missing the SslProtocols option. Added it to that version too.