### PR TITLE
Fix Silent Exception thrown in WebSocket ctor

### DIFF
--- a/Src/EngineIoClientDotNet/Client/Transports/WebSocket.cs
+++ b/Src/EngineIoClientDotNet/Client/Transports/WebSocket.cs
@@ -66,8 +66,11 @@ namespace Quobject.EngineIoClientDotNet.Client.Transports
             if (useProxy)
             {
                 var proxyUrl = WebRequest.DefaultWebProxy.GetProxy(destUrl.Uri);
-                var proxy = new HttpConnectProxy(new DnsEndPoint(proxyUrl.Host, proxyUrl.Port), destUrl.Host);
-                ws.Proxy = proxy;
+                if (proxyUrl != null)
+                {
+                    var proxy = new HttpConnectProxy(new DnsEndPoint(proxyUrl.Host, proxyUrl.Port), destUrl.Host);
+                    ws.Proxy = proxy;
+                }               
             }
             ws.Open();
         }


### PR DESCRIPTION
Its possible for the WebRequest.DefaultWebProxy.GetProxy call to return null, which causes a null reference exception to be thrown and swallowed in the Task.Run action.

I've added a simple check for the proxy object returned from GetProxy, if its null then we don't use it.